### PR TITLE
Improve monthly cost calculation in checkout

### DIFF
--- a/includes/class-wasa-kredit-checkout-payment-gateway.php
+++ b/includes/class-wasa-kredit-checkout-payment-gateway.php
@@ -361,7 +361,6 @@ class Wasa_Kredit_Checkout_Payment_Gateway extends WC_Payment_Gateway {
 			$payment_methods = Wasa_Kredit_WC()->api->get_payment_methods( number_format( $cart_total, 2, '.', '' ) );
 			if ( ! is_wp_error( $payment_methods ) ) {
 				WC()->session->set( 'wasa_kredit_payment_methods', $payment_methods );
-				WC()->session->set( 'wasa_kredit_cart_total', $cart_total );
 			}
 		}
 


### PR DESCRIPTION
Tweak in logic where `get_leasing_payment_options` wasn't updated correctly if cart total changed after customer had visited the checkout page.